### PR TITLE
Fix for when app has a UINavigationController

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -91,6 +91,8 @@
         <source-file src="src/ios/AppDelegate+IonicDeeplink.m" />
         <header-file src="src/ios/IonicDeeplinkPlugin.h" />
         <source-file src="src/ios/IonicDeeplinkPlugin.m" />
+        <header-file src="src/ios/DeeplinkService.h" />
+        <source-file src="src/ios/DeeplinkService.m" />
     </platform>
 
     <platform name="browser">

--- a/src/ios/AppDelegate+IonicDeeplink.m
+++ b/src/ios/AppDelegate+IonicDeeplink.m
@@ -1,5 +1,6 @@
 #import "AppDelegate.h"
 #import "IonicDeeplinkPlugin.h"
+#import "DeeplinkService.h"
 
 static NSString *const PLUGIN_NAME = @"IonicDeeplinkPlugin";
 
@@ -21,6 +22,7 @@ static NSString *const PLUGIN_NAME = @"IonicDeeplinkPlugin";
     IonicDeeplinkPlugin *plugin = [self.viewController getCommandInstance:PLUGIN_NAME];
 
     if(plugin == nil) {
+      [DeeplinkService setLastURL:url];
       NSLog(@"Unable to get instance of command plugin");
       return NO;
     }
@@ -43,6 +45,7 @@ static NSString *const PLUGIN_NAME = @"IonicDeeplinkPlugin";
     IonicDeeplinkPlugin *plugin = [self.viewController getCommandInstance:PLUGIN_NAME];
 
     if(plugin == nil) {
+      [DeeplinkService setLastUserActivity:userActivity];
       return NO;
     }
 

--- a/src/ios/DeeplinkService.h
+++ b/src/ios/DeeplinkService.h
@@ -1,0 +1,18 @@
+#ifndef DEEPLINK_SERVICE_H
+#define DEEPLINK_SERVICE_H
+
+#import <Foundation/Foundation.h>
+
+@interface DeeplinkService : NSObject
+
++ (void)setLastURL:(NSURL*)url;
++ (NSURL*)getLastURL;
++ (void)clearLastURL;
+
++ (void)setLastUserActivity:(NSUserActivity*)userActivity;
++ (NSUserActivity*)getLastUserActivity;
++ (void)clearLastUserActivity;
+
+@end
+
+#endif

--- a/src/ios/DeeplinkService.m
+++ b/src/ios/DeeplinkService.m
@@ -1,0 +1,69 @@
+#import "DeeplinkService.h"
+
+@implementation DeeplinkService
+
+static NSObject* deeplinkLocker;
+static NSURL* lastURL = nil;
+static NSUserActivity* lastUserActivity = nil;
+
+- (id) init
+{
+  self = [super init];
+
+  if (self)
+  {
+      deeplinkLocker = [[NSObject alloc] init];
+  }
+
+  return self;
+}
+
++ (void)setLastURL:(NSURL*)url
+{
+    @synchronized(deeplinkLocker)
+    {
+        lastURL = url;
+    }
+}
+
++ (NSURL*)getLastURL
+{
+    @synchronized(deeplinkLocker)
+    {
+        return lastURL;
+    }
+}
+
++ (void)clearLastURL
+{
+    @synchronized(deeplinkLocker)
+    {
+        lastURL = nil;
+    }
+}
+
++ (void)setLastUserActivity:(NSUserActivity*)userActivity
+{
+    @synchronized(deeplinkLocker)
+    {
+        lastUserActivity = userActivity;
+    }
+}
+
++ (NSUserActivity*)getLastUserActivity
+{
+    @synchronized(deeplinkLocker)
+    {
+        return lastUserActivity;
+    }
+}
+
++ (void)clearLastUserActivity
+{
+    @synchronized(deeplinkLocker)
+    {
+        lastUserActivity = nil;
+    }
+}
+
+@end

--- a/src/ios/IonicDeeplinkPlugin.m
+++ b/src/ios/IonicDeeplinkPlugin.m
@@ -1,11 +1,30 @@
 #import "IonicDeeplinkPlugin.h"
 
 #import <Cordova/CDVAvailability.h>
+#import "DeeplinkService.h"
 
 @implementation IonicDeeplinkPlugin
 
 - (void)pluginInitialize {
   _handlers = [[NSMutableArray alloc] init];
+  
+  NSURL* lastURL = [DeeplinkService getLastURL];
+
+  if (lastURL != nil)
+  {
+    [self handleLink:lastURL];
+  }
+
+  [DeeplinkService clearLastURL];
+
+  NSUserActivity* lastUserActivity = [DeeplinkService getLastUserActivity];
+
+  if (lastUserActivity != nil)
+  {
+    [self handleContinueUserActivity:lastUserActivity];
+  }
+
+  [DeeplinkService clearLastUserActivity];
 }
 
 /* ------------------------------------------------------------- */


### PR DESCRIPTION
Fixes:
- If app has UINavigationController as the rootView the Plugin cannot be loaded at ColdStart by storing the url that the app was started from