### PR TITLE
Add Query String and Scheme properties to parsed data object in a browser context

### DIFF
--- a/src/browser/DeeplinkProxy.js
+++ b/src/browser/DeeplinkProxy.js
@@ -1,9 +1,30 @@
+function parseSchemeFromUrl (url) {
+	var _sep = url.indexOf(':');
+	if (_sep > -1) {
+		return url.slice(0, _sep + 1);
+	}
+
+	return undefined;
+}
+
+function parseQueryStringFromUrl(url) {
+	var qs = url.indexOf('?');
+
+	if (qs > -1) {
+		return url.slice(qs + 1);
+	}
+
+	return undefined;
+}
+
 function locationToData(l) {
   return {
     url: l.href,
     path: l.pathname,
     host: l.hostname,
-    fragment: l.hash
+    fragment: l.hash,
+		scheme: parseSchemeFromUrl(l.href),
+		queryString: parseQueryStringFromUrl(l.href)
   }
 }
 


### PR DESCRIPTION
Attempts to bring data object parity to the browser context