### PR TITLE
added fix for getting and checking real path

### DIFF
--- a/www/deeplink.js
+++ b/www/deeplink.js
@@ -187,7 +187,7 @@ var IonicDeeplink = {
     }
 
     if(!data.path) {
-      if(data.host.charAt(0) != '/') data.host = '/' + data.host;
+      if(data.host.charAt(0) !== '/') data.host = '/' + data.host;
       return data.host;
     }
 
@@ -202,7 +202,7 @@ var IonicDeeplink = {
       restOfUrl = restOfUrl.slice(0);
     }
 
-    return restOfUrl;
+    return (data.host.charAt(0) !== '/' ? ('/' + data.host) : data.host) + restOfUrl;
   },
 
   onDeepLink: function(callback) {


### PR DESCRIPTION
Hi! In regards of the flow, when we pass several urls (hosts) to the route() method they start validating as for each case we extract data from the path and try to match them. When we get to _getRealPath() method - it returns extracted path without host( in current implementation ), but when this data is passed to routeMatch() method, it will never match as its length is compared to a targetPath and they would be different in any case. For this implementation, I have modified just the returning value for paths to validate and work correctly.
P.S. - that`s actually why its is working with routeWithNavController() - cause there data will always be executed with an error, but it will be processed successfully as success and error arguments are rewritten