### PR TITLE
fix(config): add domains to associated-domain entitlement for iOS builds

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -88,6 +88,25 @@
           </array>
         </config-file>
 
+        <config-file parent="com.apple.developer.associated-domains" target="*/Entitlements-Debug.plist">
+          <array>
+            <string>applinks:$DEEPLINK_HOST</string>
+            <string>applinks:$DEEPLINK_2_HOST</string>
+            <string>applinks:$DEEPLINK_3_HOST</string>
+            <string>applinks:$DEEPLINK_4_HOST</string>
+            <string>applinks:$DEEPLINK_5_HOST</string>
+          </array>
+        </config-file>
+        <config-file parent="com.apple.developer.associated-domains" target="*/Entitlements-Release.plist">
+          <array>
+            <string>applinks:$DEEPLINK_HOST</string>
+            <string>applinks:$DEEPLINK_2_HOST</string>
+            <string>applinks:$DEEPLINK_3_HOST</string>
+            <string>applinks:$DEEPLINK_4_HOST</string>
+            <string>applinks:$DEEPLINK_5_HOST</string>
+          </array>
+        </config-file>
+
         <source-file src="src/ios/AppDelegate+IonicDeeplink.m" />
         <header-file src="src/ios/IonicDeeplinkPlugin.h" />
         <source-file src="src/ios/IonicDeeplinkPlugin.m" />


### PR DESCRIPTION
This automatically enables the associated domains in the app capabilities and adds all configured domains to it.

Currently after installing and configuring the plugin one still needs to manually enable associated domains in the capabilities tab in Xcode for iOS builds and add the domains there.
But even then associated domains are only enabled **for debug builds only**! To enable them for production builds too one has to manually copy the configuration into `Entitlements-Release.plist` (see https://github.com/ionic-team/ionic-plugin-deeplinks/issues/154#issuecomment-432160543).

This current behavior is a huge inconvenience since it requires manual intervention (which it does not for Android) and is not documented in the `README.md` - it took me days to debug this and get deeplinks finally up and running.

This PR now simple adds the required parameters to the configuration so the `Entitlements-*.plist` files get updated automatically and deeplinks work without manual rework.