### PR TITLE
Revert "fix(config): add domains to associated-domain entitlement for iOS builds"

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -88,25 +88,6 @@
           </array>
         </config-file>
 
-        <config-file parent="com.apple.developer.associated-domains" target="*/Entitlements-Debug.plist">
-          <array>
-            <string>applinks:$DEEPLINK_HOST</string>
-            <string>applinks:$DEEPLINK_2_HOST</string>
-            <string>applinks:$DEEPLINK_3_HOST</string>
-            <string>applinks:$DEEPLINK_4_HOST</string>
-            <string>applinks:$DEEPLINK_5_HOST</string>
-          </array>
-        </config-file>
-        <config-file parent="com.apple.developer.associated-domains" target="*/Entitlements-Release.plist">
-          <array>
-            <string>applinks:$DEEPLINK_HOST</string>
-            <string>applinks:$DEEPLINK_2_HOST</string>
-            <string>applinks:$DEEPLINK_3_HOST</string>
-            <string>applinks:$DEEPLINK_4_HOST</string>
-            <string>applinks:$DEEPLINK_5_HOST</string>
-          </array>
-        </config-file>
-
         <source-file src="src/ios/AppDelegate+IonicDeeplink.m" />
         <header-file src="src/ios/IonicDeeplinkPlugin.h" />
         <source-file src="src/ios/IonicDeeplinkPlugin.m" />


### PR DESCRIPTION
Reverts ionic-team/ionic-plugin-deeplinks#182 until PR side effects can be debugged