### PR TITLE
Check url before handle and GooglePlus/Linkedin fix

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -75,6 +75,9 @@
             <feature name="IonicDeeplinkPlugin">
                 <param name="ios-package" value="IonicDeeplinkPlugin" onload="true" />
             </feature>
+            <preference name="URL_SCHEME" value="$URL_SCHEME" />
+            <preference name="DEEPLINK_SCHEME" value="$DEEPLINK_SCHEME" />
+            <preference name="DEEPLINK_HOST" value="$DEEPLINK_HOST" />
         </config-file>
 
         <config-file target="*-Info.plist" parent="CFBundleURLTypes">
@@ -91,10 +94,6 @@
         <source-file src="src/ios/AppDelegate+IonicDeeplink.m" />
         <header-file src="src/ios/IonicDeeplinkPlugin.h" />
         <source-file src="src/ios/IonicDeeplinkPlugin.m" />
-
-        <preference name="URL_SCHEME" value="$URL_SCHEME" />
-        <preference name="DEEPLINK_SCHEME" value="$DEEPLINK_SCHEME" />
-        <preference name="DEEPLINK_HOST" value="$DEEPLINK_HOST" />
     </platform>
 
     <platform name="browser">

--- a/plugin.xml
+++ b/plugin.xml
@@ -91,6 +91,10 @@
         <source-file src="src/ios/AppDelegate+IonicDeeplink.m" />
         <header-file src="src/ios/IonicDeeplinkPlugin.h" />
         <source-file src="src/ios/IonicDeeplinkPlugin.m" />
+
+        <preference name="URL_SCHEME" value="$URL_SCHEME" />
+        <preference name="DEEPLINK_SCHEME" value="$DEEPLINK_SCHEME" />
+        <preference name="DEEPLINK_HOST" value="$DEEPLINK_HOST" />
     </platform>
 
     <platform name="browser">

--- a/src/ios/AppDelegate+IonicDeeplink.m
+++ b/src/ios/AppDelegate+IonicDeeplink.m
@@ -57,7 +57,7 @@ static NSString *const PLUGIN_NAME = @"IonicDeeplinkPlugin";
           [openURLData setValue:annotation forKey:@"annotation"];
       }
 
-      [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
+      // [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
       [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLWithAppSourceAndAnnotationNotification object:openURLData]];
 
       // Send notice to the rest of our plugin that we didn't handle this URL

--- a/src/ios/IonicDeeplinkPlugin.m
+++ b/src/ios/IonicDeeplinkPlugin.m
@@ -37,12 +37,42 @@
 
 - (BOOL)handleLink:(NSURL *)url {
   NSLog(@"IonicDeepLinkPlugin: Handle link (internal) %@", url);
+  
+  if(![self checkUrl:url]) {
+    return NO;
+  }
 
   _lastEvent = [self createResult:url];
 
   [self sendToJs];
 
   return YES;
+}
+
+- (BOOL)checkUrl:(NSURL *)url {
+  if(url == nil) return NO;
+    
+  NSString* urlScheme = [[self.commandDelegate settings] objectForKey:@"url_scheme"];
+    
+  if(urlScheme == nil) return NO;
+    
+  NSLog(@"url scheme:%@",[url scheme]);
+  NSLog(@"url host:%@",[url host]);
+
+  if([[url scheme] isEqualToString:urlScheme]) {
+    return YES;
+  }
+    
+  NSString* deeplinkScheme = [[self.commandDelegate settings] objectForKey:@"deeplink_scheme"];
+  NSString* deeplinkHost = [[self.commandDelegate settings] objectForKey:@"deeplink_host"];
+    
+  if(deeplinkScheme!=nil && deeplinkHost != nil) {
+    if([[url scheme] isEqualToString:deeplinkScheme]&&[[url host] isEqualToString:deeplinkHost]) {
+      return YES;
+    }
+  }
+  
+  return NO;
 }
 
 - (BOOL)handleContinueUserActivity:(NSUserActivity *)userActivity {


### PR DESCRIPTION
I combined the check url from @jasonz1987: #172 and a fix for preventing the plugin from breaking other plugins like GooglePlus #174 and probably LinkedIn as well: #145

Can someone confirm this fixes their issue too so we can get this fix merged?

