### PR TITLE
Update deeplinks.js  _queryToObject call

### DIFF
--- a/www/deeplink.js
+++ b/www/deeplink.js
@@ -41,7 +41,7 @@ var IonicDeeplink = {
     this.onDeepLink(function (data) {
       var realPath = self._getRealPath(data);
 
-      var args = self._queryToObject(data.queryString);
+      var args = self._queryToObject(data.url);
 
       var matched = false;
       var finalArgs;


### PR DESCRIPTION
Update deeplinks.js _queryToOjbect call to use `data.url` instead of `data.queryString`. On Android devices, the `data.queryString` is returning the `queryString` value already decoded that when passed on to the _queryToObject function could result in some unwanted results. For example, a parameter string value that includes the `=` special character would get truncated unintentionally.