### PR TITLE
Fix imports in documentation to include /ngx

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Using [Ionic Native](https://github.com/ionic-team/ionic-native) (available in 1
 
 ```javascript
 import { Platform, NavController } from 'ionic-angular';
-import { Deeplinks } from '@ionic-native/deeplinks';
+import { Deeplinks } from '@ionic-native/deeplinks/ngx';
 
 export class MyApp {
   constructor(
@@ -84,7 +84,7 @@ If you're using Ionic 2, there is a convenience method to route automatically (s
 
 ```javascript
 import { Platform, NavController } from 'ionic-angular';
-import { Deeplinks } from '@ionic-native/deeplinks';
+import { Deeplinks } from '@ionic-native/deeplinks/ngx';
 
 export class MyApp {
   constructor(


### PR DESCRIPTION
The imports in the documentation were wrong, causing some people to create issues. I ran into this issue myself and did not know what was going wrong. The imports should have /ngx on the end in the readme, as this is what works with the latest version of the plugin.