### PR TITLE
Fix for _stripFragmentLeadingHash is not a function

### DIFF
--- a/www/deeplink.js
+++ b/www/deeplink.js
@@ -212,7 +212,7 @@ var IonicDeeplink = {
     // 3. Nope so we'll go fragment first if available as that should be what comes after
     if (!isCustomScheme) {
       if (!!data.fragment) {
-        return self._stripFragmentLeadingHash(data.fragment);
+        return this._stripFragmentLeadingHash(data.fragment);
       }
     }
 
@@ -227,7 +227,7 @@ var IonicDeeplink = {
 
     // 5. We'll use fragment next if we're in a custom scheme, though this might need a little more thought
     if (isCustomScheme && !!data.fragment) {
-      return self._stripFragmentLeadingHash(data.fragment);
+      return this._stripFragmentLeadingHash(data.fragment);
     }
 
     // 6. Last resort - no obvious path, fragment or host, so we


### PR DESCRIPTION
This pull request is to fix this issue I get in console:

`Uncaught TypeError: self._stripFragmentLeadingHash is not a function
    at Object._getRealPath (plugins/ionic-plugin-deeplinks/www/deeplink.js:231)
    at plugins/ionic-plugin-deeplinks/www/deeplink.js:43
    at innerCB (plugins/ionic-plugin-deeplinks/www/deeplink.js:263)
    at Object.callbackFromNative (cordova.js:287)
    at <anonymous>:1:9`