### PR TITLE
fix: routeMatch never matches given routes

### DIFF
--- a/www/deeplink.js
+++ b/www/deeplink.js
@@ -50,7 +50,7 @@ var IonicDeeplink = {
       for (var targetPath in paths) {
         pathData = paths[targetPath];
 
-        var matchedParams = self.routeMatch(pathData, realPath);
+        var matchedParams = self.routeMatch(targetPath, realPath);
 
         if (matchedParams !== false) {
           matched = true;


### PR DESCRIPTION
The pathData was being used in the routeMatch comparison function instead of the key which contains the path itself.

Fixes #241
Fixes #243