### PR TITLE
iOS14 AppTrackingTransparency advertisingIdentifier removed

### DIFF
--- a/src/ios/IonicDeeplinkPlugin.m
+++ b/src/ios/IonicDeeplinkPlugin.m
@@ -123,22 +123,8 @@
 - (void)getHardwareInfo:(CDVInvokedUrlCommand *)command {
   NSMutableDictionary *info = [[NSMutableDictionary alloc] init];
 
-  // Get the as id in a way that doesn't require it be linked
-  Class asIdManClass = NSClassFromString(@"ASIdentifierManager");
 
-  if(asIdManClass) {
-    SEL sharedManagerSel = NSSelectorFromString(@"sharedManager");
-    id sharedManager = ((id (*)(id, SEL))[asIdManClass methodForSelector:sharedManagerSel])(asIdManClass, sharedManagerSel);
-    SEL advertisingIdentifierSelector = NSSelectorFromString(@"advertisingIdentifier");
-    NSUUID *uuid = ((NSUUID* (*)(id, SEL))[sharedManager methodForSelector:advertisingIdentifierSelector])(sharedManager, advertisingIdentifierSelector);
-    NSString *adId = [uuid UUIDString];
-
-    // Check if ad tracking is disabled (happens on iOS 10+)
-    NSString *disabledString = @"00000000-0000-0000-0000-000000000000";
-    if (![adId isEqualToString:disabledString]) {
-      [info setObject:adId forKey:@"adid"];
-    }
-  }
+  // Removing part where advertisingIdentifier is being used to keep the functional part working.
 
   NSString *uuid = [[UIDevice currentDevice].identifierForVendor UUIDString];
 


### PR DESCRIPTION
Hi, 

As mentioned in the commit message, I have removed the part where advertisingIdentifier is used which is causing iOS app rejection. There is an open issue which talks about it [(#246)](https://github.com/ionic-team/ionic-plugin-deeplinks/issues/246).

Fixes [#246](https://github.com/ionic-team/ionic-plugin-deeplinks/issues/246)